### PR TITLE
convert table to markdown, instead of HTML

### DIFF
--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -203,44 +203,15 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 To bootstrap the process, the TOC proposes the following SIGs, and projects assigned to each SIG. Clearly all of these SIG’s will not be fully-formed overnight or begin operating immediately, so the TOC itself will fulfill the duties of not-yet-formed SIG’s until they are.  We can however, fairly immediately, assign one voting member of the TOC as liason for each SIG, and prioritize the order of formation of the SIGs, starting immediately with the most pressing ones. 
 
-<table>
-  <tr>
-    <td>Name (to be finalised)</td>
-    <td>Area</td>
-    <td>Current CNCF Projects</td>
-  </tr>
-  <tr>
-    <td>Traffic</td>
-    <td>networking, service discovery, load balancing, service mesh, RPC, pubsub, etc.</td>
-    <td>Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI</td>
-  </tr>
-  <tr>
-    <td>Observability</td>
-    <td>monitoring, logging, tracing, profiling, etc.
-</td>
-    <td>Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics, </td>
-  </tr>
-  <tr>
-    <td>Governance</td>
-    <td>security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc</td>
-    <td>SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco, </td>
-  </tr>
-  <tr>
-    <td>App Dev, Ops & Testing</td>
-    <td>PaaS, Serverless, Operators,... CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc.</td>
-    <td>Helm, CloudEvents, Telepresence, Buildpacks, (CNCF CI)</td>
-  </tr>
-  <tr>
-    <td>Core and Applied Architectures</td>
-    <td>orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc).</td>
-    <td>Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet</td>
-  </tr>
-  <tr>
-    <td>Storage</td>
-    <td>Block, File and Object Stores, Databases, Key-Value stores etc.</td>
-    <td>TiKV, etcd, Vitess, Rook</td>
-  </tr>
-</table>
+
+| Name (to be finalised)  | Area        | Current CNCF Projects 
+| ------------------------|-------------|-----------------------
+| Traffic | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI
+| Observability | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics
+| Governance | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco
+| App Dev, Ops & Testing | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks, (CNCF CI)
+| Core and Applied Architectures | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet
+| Storage | Block, File and Object Stores, Databases, Key-Value stores etc. | TiKV, etcd, Vitess, Rook
 
 
 The TOC and CNCF Staff will draft an initial set of charters for the above, and solicit/elect suitable chairs.

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -45,7 +45,7 @@ CNCF SIGs are modelled on Kubernetes SIGs.  Differences are intended to be minim
 
 It is the desire of the TOC that the CNCF SIGs, under guidance from the TOC, provide high-quality technical expertise, unbiased information and proactive leadership within their category.  The TOC makes use of this input to act as an informed and effective executive board to select and promote appropriate CNCF projects and practices, and to disseminate high quality information to end users and the cloud-native community in general.  SIGs explicitly have no direct authority over CNCF projects. In particular, the creation of CNCF SIG’s does not change the existing, successfully practiced [charter](https://github.com/cncf/foundation/blob/master/charter.md) goal that "Projects.. will be ‘lightly’ subject to the Technical Oversight Committee". 
 
-The SIGs should strive to present the TOC with easily understandable and votable "propositions", each of which is supported by clear written evidence.  A proposition may be “to approve this project for incubation based on this [written ](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)[due diligence](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)[ investigation](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)”, or “to approve this landscape document based on these clear goals and evidence that it achieves them”.  It is of utmost importance that the information and proposals provided to the TOC by SIGs be highly accurate and unbiased, driven by the goal to improve the CNCF as a whole, rather than benefit one project or company over another.  We believe that the rising tide lifts all boats, and that is our goal.
+The SIGs should strive to present the TOC with easily understandable and votable "propositions", each of which is supported by clear written evidence.  A proposition may be “to approve this project for incubation based on this [written due diligence investigation](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)”, or “to approve this landscape document based on these clear goals and evidence that it achieves them”.  It is of utmost importance that the information and proposals provided to the TOC by SIGs be highly accurate and unbiased, driven by the goal to improve the CNCF as a whole, rather than benefit one project or company over another.  We believe that the rising tide lifts all boats, and that is our goal.
 
 Key ideas here:
 
@@ -59,51 +59,51 @@ SIGs may choose to spawn focussed and time-limited working groups to achieve som
 
 #### Project Handling:
 
-    * Understand and document a high level roadmap of projects within this space, including CNCF and non-CNCF projects. Identify gaps in project landscape.
+  * Understand and document a high level roadmap of projects within this space, including CNCF and non-CNCF projects. Identify gaps in project landscape.
 
-    * For projects that fall within the CNCF, perform health checks.
+  * For projects that fall within the CNCF, perform health checks.
 
-    * Perform discovery of and outreach to candidate projects
+  * Perform discovery of and outreach to candidate projects
 
-    * Help candidate projects prepare for presentation to the TOC
+  * Help candidate projects prepare for presentation to the TOC
 
-    * Every CNCF project will be assigned to one suitable SIG by the TOC.
+  * Every CNCF project will be assigned to one suitable SIG by the TOC.
 
 #### End User Education (Outbound Communication)
 
-    * Provide up-to-date, high quality, unbiased and easy-to-consume material to help end users to understand and effectively adopt cloud-native technologies and practises within the SIG’s area, for example:
+  * Provide up-to-date, high quality, unbiased and easy-to-consume material to help end users to understand and effectively adopt cloud-native technologies and practises within the SIG’s area, for example:
 
-        * White papers, presentations, videos, or other forms of training clarifying terminology, comparisons of different approaches, available projects or products, common or recommended practises, trends, illustrative successes and failures, etc.
+    * White papers, presentations, videos, or other forms of training clarifying terminology, comparisons of different approaches, available projects or products, common or recommended practises, trends, illustrative successes and failures, etc.
 
-        * As far as possible, information should be based on research and fact gathering, rather than pure marketing or speculation.  
+    * As far as possible, information should be based on research and fact gathering, rather than pure marketing or speculation.
 
 #### End User Input Gathering (Inbound Communication)
 
-    * Gather useful end user input and feedback regarding expectations, pain points, primary use cases etc.
+  * Gather useful end user input and feedback regarding expectations, pain points, primary use cases etc.
 
-    * Compile this into easily consumable reports and/or presentations to assist projects with feature design, prioritization, UX etc.
+  * Compile this into easily consumable reports and/or presentations to assist projects with feature design, prioritization, UX etc.
 
 #### Community Enablement
 
-    * SIGs are open organizations with meetings, meeting agendas and notes, mailing lists, and other communications in the open
+  * SIGs are open organizations with meetings, meeting agendas and notes, mailing lists, and other communications in the open
 
-    * The mailing list, SIG meeting calendar, and other communication documents of the SIG will be openly published and maintained
+  * The mailing list, SIG meeting calendar, and other communication documents of the SIG will be openly published and maintained
 
 #### As Trusted Expert Advisors to the TOC
 
-    * Perform technical due diligence on new and graduating projects, and advise TOC on findings.
+  * Perform technical due diligence on new and graduating projects, and advise TOC on findings.
 
-    * Be involved with, or periodically check in with projects in their area, and advise TOC on health, status and proposed actions (if any) as necessary or on request.
+  * Be involved with, or periodically check in with projects in their area, and advise TOC on health, status and proposed actions (if any) as necessary or on request.
 
 #### SIG Charter:
 
-    * This is formally reviewed annually, and approved by the TOC.  The charter must clearly articulate:
+  * This is formally reviewed annually, and approved by the TOC.  The charter must clearly articulate:
 
-        * what is in and out of scope of the SIG,
+    * what is in and out of scope of the SIG,
 
-        * whether and how it overlaps and interfaces with other CNCF SIG’s or other relevant groups, and 
+    * whether and how it overlaps and interfaces with other CNCF SIG’s or other relevant groups, and
 
-        * how it operates and is governed, and specifically whether and how it deviates from standard SIG operating guidelines provided by the TOC.  Deviation from these guidelines is discouraged, unless there are good and well-documented reasons for such divergence, approved by the TOC. 
+    * how it operates and is governed, and specifically whether and how it deviates from standard SIG operating guidelines provided by the TOC.  Deviation from these guidelines is discouraged, unless there are good and well-documented reasons for such divergence, approved by the TOC.
 
 See [Example Responsibilities of a CNCF SIG](https://docs.google.com/document/d/1L9dJl5aBFnN5KEf82J689FY0UtnUawnt9ooCq8SkO_w/edit?usp=sharing).
 
@@ -177,7 +177,7 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 * SIGs must have a documented governance process that encourages community participation and clear guidelines to avoid biased decision-making.  
 
-    * NOTE: aim here is to align with "minimal viable" model of the CNCF projects, and only have such governance as is needed, not anything too burdensome
+  * NOTE: aim here is to align with "minimal viable" model of the CNCF projects, and only have such governance as is needed, not anything too burdensome
 
 * They may grow a set of practices over time in the same way as an OSS Project, provided this is consistent with CNCF Operating Principles. 
 
@@ -193,9 +193,9 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 * In the event that a SIG is unable to regularly establish quorum, or fulfill the responsibilities and/or regularly report to the TOC, the TOC will:
 
-    * Consider retiring the SIG after 3 months
+  * Consider retiring the SIG after 3 months
 
-    * Must retire the SIG after 6 months
+  * Must retire the SIG after 6 months
 
 * The TOC may, by means of a 2/3 majority vote, declare "no confidence" in the SIG.  In this event, the TOC may then vote to retire or reconstitute the SIG.
 


### PR DESCRIPTION
I created this as a separate PR, since table is [extended syntax](https://www.markdownguide.org/extended-syntax/#tables)

it's supported by github and makes text files easier to read (IMHO)

this includes minor formatting fixes from  https://github.com/quinton-hoole-2/toc/pull/1 which I assume is non-controversial :) . -- if you want both, you can just merge this one